### PR TITLE
Add ensemble voting for prototype selections

### DIFF
--- a/Pipeline/Pipeline.py
+++ b/Pipeline/Pipeline.py
@@ -573,13 +573,11 @@ class Pipeline:
             val_loss = self._train_loop(optimizer, criterion, epochs=epochs, patience=patience)
             return self.best_model, val_loss
 
-    def evaluate(self, threshold: float = 0.5):
-        """
-        Evaluate on the test set. We compute softmax => take class-1 probability => compare with threshold.
-        Default threshold=0.5.
-        """
+    def predict(self, threshold: float = 0.5):
+        """Return predicted and true labels on the test set."""
         if self.test_loader is None:
-            raise ValueError("Call data_loader() before evaluate().")
+            raise ValueError("Call data_loader() before predict().")
+
         self.model.eval()
 
         preds, labels = [], []
@@ -587,14 +585,21 @@ class Pipeline:
             for x, y in self.test_loader:
                 x, y = x.to(self.device).float(), y.to(self.device)
                 logits = self.model(x)
-                # Convert logits to softmax probability for class 1
                 probs = nn.functional.softmax(logits, dim=1)[:, 1]
                 pred = (probs >= threshold).long()
                 preds.extend(pred.cpu().numpy())
                 labels.extend(y.cpu().numpy())
 
-        preds = np.array(preds)
-        labels = np.array(labels)
+        return np.array(preds), np.array(labels)
+
+    def evaluate(self, threshold: float = 0.5):
+        """
+        Evaluate on the test set. We compute softmax => take class-1 probability => compare with threshold.
+        Default threshold=0.5.
+        """
+        if self.test_loader is None:
+            raise ValueError("Call data_loader() before evaluate().")
+        preds, labels = self.predict(threshold=threshold)
         acc = accuracy_score(labels, preds)
         f1 = self._binary_f1(labels, preds)
         self.confusion_mat = confusion_matrix(labels, preds)

--- a/Pipeline/ensemble.py
+++ b/Pipeline/ensemble.py
@@ -1,0 +1,62 @@
+import os
+from typing import Iterable
+
+import numpy as np
+from sklearn.metrics import accuracy_score, f1_score
+
+from .Pipeline import Pipeline
+
+
+def majority_vote(pred_list: Iterable[np.ndarray]) -> np.ndarray:
+    """Return element-wise majority vote across prediction arrays."""
+    stack = np.stack(pred_list, axis=0)
+    votes = []
+    for i in range(stack.shape[1]):
+        counts = np.bincount(stack[:, i].astype(int))
+        votes.append(np.argmax(counts))
+    return np.array(votes)
+
+
+def ensemble_pipeline(
+    model_class,
+    file_path: str,
+    n_vars: int,
+    num_classes: int,
+    selection_types: Iterable[str],
+    distance_metrics: Iterable[str],
+    result_dir: str | None = None,
+    num_prototypes: int = 8,
+    threshold: float = 0.5,
+    **train_kwargs,
+):
+    """Train pipelines for each prototype selection and metric then do majority vote."""
+    preds_all = []
+    labels_ref = None
+    for sel in selection_types:
+        for metric in distance_metrics:
+            sub_dir = None
+            if result_dir is not None:
+                sub_dir = os.path.join(result_dir, f"{sel}_{metric}")
+            pipe = Pipeline(
+                model_class=model_class,
+                file_path=file_path,
+                n_vars=n_vars,
+                num_classes=num_classes,
+                result_dir=sub_dir,
+                use_prototype=True,
+                num_prototypes=num_prototypes,
+                prototype_selection_type=sel,
+                prototype_distance_metric=metric,
+            )
+            pipe.train(**train_kwargs)
+            preds, labels = pipe.predict(threshold=threshold)
+            preds_all.append(preds)
+            if labels_ref is None:
+                labels_ref = labels
+    if labels_ref is None:
+        raise ValueError("No predictions were produced.")
+
+    final_preds = majority_vote(preds_all)
+    acc = accuracy_score(labels_ref, final_preds)
+    f1 = f1_score(labels_ref, final_preds)
+    return final_preds, {"accuracy": acc, "f1": f1}


### PR DESCRIPTION
## Summary
- add `predict` method so pipelines can output predictions
- refactor `evaluate` to reuse `predict`
- implement `ensemble_pipeline` utility with majority vote across prototype methods

## Testing
- `python -m py_compile Pipeline/Pipeline.py Pipeline/ensemble.py`
- `python - <<'PY'
from Pipeline.ensemble import majority_vote
import numpy as np
preds = [np.array([0,1,0]), np.array([1,1,0]), np.array([1,0,0])]
print('vote', majority_vote(preds))
PY`